### PR TITLE
Module resolver

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -93,12 +93,14 @@ void ExitOnPromiseRejectCallback(PromiseRejectMessage promise_reject_message) {
 }
 
 MaybeLocal<Module> ResolveCallback(Local<Context> context,
-                                   Local<String> name,
+                                   Local<String> specifier,
                                    Local<Module> referrer) {
   auto isolate = Isolate::GetCurrent();
   worker* w = (worker*)isolate->GetData(0);
 
-  String::Utf8Value str(name);
+  HandleScope handle_scope(isolate);
+
+  String::Utf8Value str(specifier);
   const char* moduleName = ToCString(str);
 
   if (w->modules.count(moduleName) == 0) {

--- a/binding.cc
+++ b/binding.cc
@@ -93,6 +93,20 @@ void ExitOnPromiseRejectCallback(PromiseRejectMessage promise_reject_message) {
   exit(1);
 }
 
+MaybeLocal<Module> ResolveCallback(Local<Context> context, Local<String> name, Local<Module> referrer) {
+
+  String::Utf8Value str(name);
+  const char* moduleName = ToCString(str);
+
+  if (modules.count(moduleName) == 0) {
+    return MaybeLocal<Module>();
+  }
+
+  Isolate* isolate = context->GetIsolate();
+
+  return modules[moduleName]->Get(isolate);
+}
+
 // Exception details will be appended to the first argument.
 std::string ExceptionString(worker* w, TryCatch* try_catch) {
   std::string out;
@@ -198,21 +212,6 @@ int worker_load(worker* w, char* name_s, char* source_s) {
   }
 
   return 0;
-}
-
-
-MaybeLocal<Module> ResolveCallback(Local<Context> context, Local<String> name, Local<Module> referrer) {
-
-  String::Utf8Value str(name);
-  const char* moduleName = ToCString(str);
-
-  if (modules.count(moduleName) == 0) {
-    return MaybeLocal<Module>();
-  }
-
-  Isolate* isolate = context->GetIsolate();
-
-  return modules[moduleName]->Get(isolate);
 }
 
 int worker_load_module(worker* w, char* name_s, char* source_s) {

--- a/binding.cc
+++ b/binding.cc
@@ -38,7 +38,7 @@ struct worker_s {
   std::string last_exception;
   Persistent<Function> recv;
   Persistent<Context> context;
-  std::map<std::string, Persistent<Module>*> modules;
+  std::map<std::string, Eternal<Module>> modules;
 };
 
 // Extracts a C string from a V8 Utf8Value.
@@ -103,7 +103,7 @@ MaybeLocal<Module> ResolveCallback(Local<Context> context, Local<String> name, L
     return MaybeLocal<Module>();
   }
 
-  return w->modules[moduleName]->Get(isolate);
+  return w->modules[moduleName].Get(isolate);
 }
 
 // Exception details will be appended to the first argument.
@@ -247,9 +247,8 @@ int worker_load_module(worker* w, char* name_s, char* source_s) {
     return 1;
   }
 
-  Persistent<Module> persModule(w->isolate, module);
-  w->modules[name_s] = &persModule;
-  // persModule.Reset(w->isolate, module);
+  Eternal<Module> persModule(w->isolate, module);
+  w->modules[name_s] = persModule;
 
   Maybe<bool> ok = module->InstantiateModule(context, ResolveCallback);
 

--- a/binding.cc
+++ b/binding.cc
@@ -29,6 +29,7 @@ IN THE SOFTWARE.
 #include "binding.h"
 #include "libplatform/libplatform.h"
 #include "v8.h"
+#include "_cgo_export.h"
 
 using namespace v8;
 
@@ -101,7 +102,18 @@ MaybeLocal<Module> ResolveCallback(Local<Context> context,
   HandleScope handle_scope(isolate);
 
   String::Utf8Value str(specifier);
-  const char* moduleName = ToCString(str);
+  char* moduleName = *str;
+
+  auto ret = moduleCb(moduleName, w->table_index);
+  if (ret != 0) {
+    std::string out;
+    out.append("Unable to resolve module (");
+    out.append(moduleName);
+    out.append(")");
+    out.append("\n");
+    w->last_exception = out;
+    return MaybeLocal<Module>();
+  }
 
   if (w->modules.count(moduleName) == 0) {
     std::string out;
@@ -177,7 +189,6 @@ std::string ExceptionString(worker* w, TryCatch* try_catch) {
 }
 
 extern "C" {
-#include "_cgo_export.h"
 
 const char* worker_version() { return V8::GetVersion(); }
 

--- a/binding.cc
+++ b/binding.cc
@@ -100,6 +100,12 @@ MaybeLocal<Module> ResolveCallback(Local<Context> context, Local<String> name, L
   const char* moduleName = ToCString(str);
 
   if (w->modules.count(moduleName) == 0) {
+    std::string out;
+    out.append("Module (");
+    out.append(moduleName);
+    out.append(") has not been loaded");
+    out.append("\n");
+    w->last_exception = out;
     return MaybeLocal<Module>();
   }
 
@@ -253,8 +259,11 @@ int worker_load_module(worker* w, char* name_s, char* source_s) {
   Maybe<bool> ok = module->InstantiateModule(context, ResolveCallback);
 
   if (!ok.FromMaybe(false)) {
-    assert(try_catch.HasCaught());
-    w->last_exception = ExceptionString(w, &try_catch);
+    // TODO: I'm not sure if this is needed
+    if (try_catch.HasCaught()) {
+      assert(try_catch.HasCaught());
+      w->last_exception = ExceptionString(w, &try_catch);
+    }
     return 2;
   }
 

--- a/binding.cc
+++ b/binding.cc
@@ -92,7 +92,9 @@ void ExitOnPromiseRejectCallback(PromiseRejectMessage promise_reject_message) {
   exit(1);
 }
 
-MaybeLocal<Module> ResolveCallback(Local<Context> context, Local<String> name, Local<Module> referrer) {
+MaybeLocal<Module> ResolveCallback(Local<Context> context,
+                                   Local<String> name,
+                                   Local<Module> referrer) {
   auto isolate = Isolate::GetCurrent();
   worker* w = (worker*)isolate->GetData(0);
 

--- a/binding.h
+++ b/binding.h
@@ -44,6 +44,7 @@ worker* worker_new(int table_index);
 // returns nonzero on error
 // get error from worker_last_exception
 int worker_load(worker* w, char* name_s, char* source_s);
+int worker_load_module(worker* w, char* name_s, char* source_s);
 
 const char* worker_last_exception(worker* w);
 

--- a/worker.go
+++ b/worker.go
@@ -185,6 +185,23 @@ func (w *Worker) Load(scriptName string, code string) error {
 	return nil
 }
 
+// LoadModule loads and executes a javascript module with filename specified by
+// scriptName and the contents of the module specified by the param code.
+// All `import` dependencies must be loaded before a script otherwise it will error.
+func (w *Worker) LoadModule(scriptName string, code string) error {
+	scriptName_s := C.CString(scriptName)
+	code_s := C.CString(code)
+	defer C.free(unsafe.Pointer(scriptName_s))
+	defer C.free(unsafe.Pointer(code_s))
+
+	r := C.worker_load_module(w.worker.cWorker, scriptName_s, code_s)
+	if r != 0 {
+		errStr := C.GoString(C.worker_last_exception(w.worker.cWorker))
+		return errors.New(errStr)
+	}
+	return nil
+}
+
 // Same as Send but for []byte. $recv callback will get an ArrayBuffer.
 func (w *Worker) SendBytes(msg []byte) error {
 	msg_p := C.CBytes(msg)

--- a/worker_test.go
+++ b/worker_test.go
@@ -222,18 +222,16 @@ func TestModules(t *testing.T) {
 		t.Fatal("shouldn't recieve Message")
 		return nil
 	})
-	exportCode := `
+	err1 := worker.LoadModule("dependency.js", `
 		export const test = "ready";
-	`
-	err1 := worker.LoadModule("dependency.js", exportCode)
+	`)
 	if err1 != nil {
 		t.Fatal(err1)
 	}
-	importCode := `
+	err2 := worker.LoadModule("code.js", `
 		import { test } from "dependency.js";
 		V8Worker2.print(test);
-	`
-	err2 := worker.LoadModule("code.js", importCode)
+	`)
 	if err2 != nil {
 		t.Fatal(err2)
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -222,23 +222,33 @@ func TestModules(t *testing.T) {
 		t.Fatal("shouldn't recieve Message")
 		return nil
 	})
-	err1 := worker.LoadModule("dependency.js", `export const test = "ready";`)
+	exportCode := `
+		export const test = "ready";
+	`
+	err1 := worker.LoadModule("dependency.js", exportCode)
 	if err1 != nil {
 		t.Fatal(err1)
 	}
-	err2 := worker.LoadModule("code.js", `import { test } from "dependency.js"; V8Worker2.print(test);`)
+	importCode := `
+		import { test } from "dependency.js";
+		V8Worker2.print(test);
+	`
+	err2 := worker.LoadModule("code.js", importCode)
 	if err2 != nil {
 		t.Fatal(err2)
 	}
 }
 
 func TestModulesMissingDependency(t *testing.T) {
-	// I believe this SIGABRTs currently
 	worker := New(func(msg []byte) []byte {
 		t.Fatal("shouldn't recieve Message")
 		return nil
 	})
-	err := worker.LoadModule("code.js", `import { test } from "missing.js"; V8Worker2.print(test);`)
+	importCode := `
+		import { test } from "missing.js";
+		V8Worker2.print(test);
+	`
+	err := worker.LoadModule("code.js", importCode)
 	errorContains(t, err, "missing.js")
 }
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -239,9 +239,7 @@ func TestModulesMissingDependency(t *testing.T) {
 		return nil
 	})
 	err := worker.LoadModule("code.js", `import { test } from "missing.js"; V8Worker2.print(test);`)
-	if err != nil {
-		t.Fatal(err)
-	}
+	errorContains(t, err, "missing.js")
 }
 
 // Test breaking script execution

--- a/worker_test.go
+++ b/worker_test.go
@@ -217,6 +217,33 @@ func TestRequestFromJS(t *testing.T) {
 	}
 }
 
+func TestModules(t *testing.T) {
+	worker := New(func(msg []byte) []byte {
+		t.Fatal("shouldn't recieve Message")
+		return nil
+	})
+	err1 := worker.LoadModule("dependency.js", `export const test = "ready";`)
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	err2 := worker.LoadModule("code.js", `import { test } from "dependency.js"; V8Worker2.print(test);`)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+}
+
+func TestModulesMissingDependency(t *testing.T) {
+	// I believe this SIGABRTs currently
+	worker := New(func(msg []byte) []byte {
+		t.Fatal("shouldn't recieve Message")
+		return nil
+	})
+	err := worker.LoadModule("code.js", `import { test } from "missing.js"; V8Worker2.print(test);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Test breaking script execution
 func TestWorkerBreaking(t *testing.T) {
 	worker := New(func(msg []byte) []byte {


### PR DESCRIPTION
@ry this is basically the same as #3 but adds a commit that exposes a `SetModuleResolver` method on each Worker. Inside this callback, you can implement any sort of module loading logic you want (helpful for Deno's network/filesystem module loading?).

I don't think this is an ideal API for assigning the `ModuleResolverCallback` so I wanted to open this as a separate PR where we can discuss the API.