### PR TITLE
Allow depot_tools path override

### DIFF
--- a/build.py
+++ b/build.py
@@ -12,6 +12,7 @@ parser = argparse.ArgumentParser(description="v8worker2 build.py")
 parser.add_argument('--rebuild', dest='rebuild', action='store_true')
 parser.add_argument('--use_ccache', dest='use_ccache', action='store_true')
 parser.add_argument('--out_path', nargs=1, dest='out_path', type=str, action='store')
+parser.add_argument('--depot_tools_path', nargs=1, dest='depot_tools_path', type=str, action='store')
 parser.set_defaults(rebuild=False, use_ccache=False, out_path=None)
 args = parser.parse_args()
 
@@ -24,6 +25,8 @@ if args.out_path:
   out_path = args.out_path[0]
 print("out_path %s" % args.out_path)
 v8build_path = os.path.join(out_path, "v8build")
+if args.depot_tools_path:
+  depot_tools = args.depot_tools_path[0]
 
 # To get a list of args
 #   cd v8 && ../depot_tools/gn args ../out/v8build/ --list


### PR DESCRIPTION
Fixed #10 for me.
Before:
```
% ./build.py
Rebuilding V8
Fetching dependencies.
Running depot tools as root is sad.
Syncing projects: 100% (24/24), done.                                   
Running hooks: 100% (28/28), done.              
Traceback (most recent call last):
  File "./build.py", line 155, in <module>
    main()
  File "./build.py", line 89, in main
    lib_fn = Rebuild()
  File "./build.py", line 104, in Rebuild
    assert os.path.exists(gn_path)
AssertionError
```
After:
```
% ./build.py --depot_tools_path=./v8/third_party/depot_tools
Rebuilding V8
Fetching dependencies.
Syncing projects: 100% (24/24), done.                                   
Running hooks: 100% (28/28), done.              
Running gn
Done. Made 118 targets from 77 files in 471ms
Running ninja
v8_path = /Users/matias/dev/v8worker2/v8
ninja: Entering directory `/Users/matias/dev/v8worker2/out/v8build'
ninja: no work to do.
lib_fn = /Users/matias/dev/v8worker2/out/v8build/obj/libv8_monolith.a
Wrote /Users/matias/dev/v8worker2/v8.pc
```