### PR TITLE
Correct GOPATH use to support lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ get`.
 To install:
 ```
 go get github.com/ry/v8worker2
-cd `go env GOPATH`/src/github.com/ry/v8worker2
+cd "$(go list -f '{{.Dir}}' github.com/ry/v8worker2)"
 ./build.py # Will take ~30 minutes to compile.
 go test
 ```


### PR DESCRIPTION
GOPATH is a list as documented at
https://golang.org/cmd/go/#hdr-GOPATH_environment_variable

This commit updates the build instructions to use go list which handles
GOAPTH properly.

The new command also correctly handles spaces in filenames.