### PR TITLE
Add worker.SetNearHeapLimitCallback

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -61,6 +61,11 @@ void FatalErrorCallback2(const char* location, const char* message) {
 }
 */
 
+size_t OnNearHeapLimitCallback(void *data, size_t current_heap_limit, size_t initial_heap_limit) {
+  worker* w = (worker*)data;
+  return nearHeapLimitCb(current_heap_limit, initial_heap_limit, w->table_index);
+}
+
 void ExitOnPromiseRejectCallback(PromiseRejectMessage promise_reject_message) {
   auto isolate = Isolate::GetCurrent();
   worker* w = (worker*)isolate->GetData(0);
@@ -434,6 +439,7 @@ worker* worker_new(int table_index) {
   // w->isolate->SetAbortOnUncaughtExceptionCallback(AbortOnUncaughtExceptionCallback);
   // w->isolate->AddMessageListener(MessageCallback2);
   // w->isolate->SetFatalErrorHandler(FatalErrorCallback2);
+  w->isolate->AddNearHeapLimitCallback(OnNearHeapLimitCallback, (void *) w);
   w->isolate->SetPromiseRejectCallback(ExitOnPromiseRejectCallback);
   w->isolate->SetData(0, w);
   w->table_index = table_index;


### PR DESCRIPTION
Add a worker.SetNearHeapLimitCallback API to monitor third-party code memory usag. This API providing an opportunity to terminate when memory exceeds a threshold.

eg:
```golang
package main

import "fmt"
import "time"
import "github.com/zhangyuanwei/v8worker2"

func main() {

	// set v8 heap limit to 10M
	args := []string{"--max-semi-space-size=10", "--max-old-space-size=10"}
	v8worker2.SetFlags(args)

	go func() {
		worker := v8worker2.New(func(msg []byte) []byte {
			return nil
		})

		worker.SetNearHeapLimitCallback(func(currentHeapLimit uint, initialHeapLimit uint) uint {
			fmt.Printf("near heap limit:[currentHeapLimit:%d, initialHeapLimit:%d]\n", currentHeapLimit, initialHeapLimit)
			worker.TerminateExecution()
			return currentHeapLimit + (10 * 1024 * 1024)
		})

		fmt.Println("worker start")
                // This code will cause a fatal error (OOM)
		worker.Load("oom.js", "var strArr = [\"abcd\"]; while(true){ strArr.push(strArr.join()); }")
		fmt.Println("worker end")
	}()

	for {
		time.Sleep(time.Second)
	}
}
```