### PR TITLE
README: Use go get -d to retrieve v8worker2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ get`.
 
 To install:
 ```
-go get github.com/ry/v8worker2
+go get -d github.com/ry/v8worker2
 cd `go env GOPATH`/src/github.com/ry/v8worker2
 ./build.py # Will take ~30 minutes to compile.
 go test


### PR DESCRIPTION
The very first time one tries to do a go get, it fails with:

```
  # pkg-config --cflags  -- v8.pc
  Failed to open 'v8.pc': No such file or directory
  No package 'v8.pc' found
  pkg-config: exit status 1
```

because go get will try to build the package and v8 hasn't been built yet and
the cgo pass of the compilation can't find the pkg-config file.

To avoid that, use the -d option: go get will only download the package and not
build it.