### PR TITLE
Don't use shallow clones for update the v8 submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "v8"]
 	path = v8
 	url = https://github.com/v8/v8.git
-	branch = 6.6.164
-	shallow = true
+	branch = 6.8-lkgr
 [submodule "depot_tools"]
 	path = depot_tools
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git
-	shallow = true


### PR DESCRIPTION
The shallow setting this is the cause of those two errors:

```
Submodule 'depot_tools' (https://chromium.googlesource.com/chromium/tools/depot_tools.git) registered for path 'depot_tools'
Submodule 'v8' (https://github.com/v8/v8.git) registered for path 'v8'
Cloning into '/go/src/github.com/ry/v8worker2/depot_tools'...
Cloning into '/go/src/github.com/ry/v8worker2/v8'...
From https://chromium.googlesource.com/chromium/tools/depot_tools
 * branch              f16fdf3165b8b86d10386d18a6b6075169c10e15 -> FETCH_HEAD
error: no such remote ref fe12316ec4b4a101923e395791ca55442e62f4cc
Fetched in submodule path 'v8', but it did not contain fe12316ec4b4a101923e395791ca55442e62f4cc. Direct fetching of that commit failed.
package github.com/ry/v8worker2: exit status 1
```
and:

```
depot_tools update failed. Conflict in /go/src/github.com/dlespiau/v8worker2/depot_tools
```

Current theory is that shallow clones aren't enough to find the right commit
(for the v8 issue that is), even when specifying the right branch to look for
it.

So:

- Don't use shallow clones
- Specify the right branch where to find 6.8 releases, this should help when
  updating the submodule if one wants to follow the 6.8.x.y releases.

Fixes: #9